### PR TITLE
Add changelog and update framework dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+
+## [1.0.0] - 2025-10-06
+
+### Added
+- Initial public release of Glueful API Skeleton.
+- Glueful framework integration (`glueful/framework` ^1.3.0).
+- Default routes: `GET /` (welcome payload) and `GET /health` (lightweight health check).
+- `App\Controllers\WelcomeController` returning version and timestamp.
+- Bootstrap and entrypoint: `bootstrap/app.php`, `public/index.php`.
+- Configuration suite under `config/` (app, database, logging, queue, session, events, schedule, security, serviceproviders, extensions, image).
+- SQLite default storage at `storage/database/glueful.sqlite` with convenience setup in post-create script.
+- Database migrations for core tables (initial schema, queue, schedules, archive, locks, audit logs, notifications).
+- Composer scripts for local workflow: `serve`, `migrate`, `key:generate`, `glueful install`, and PHP_CodeSniffer tooling.
+- Basic test scaffolding (`tests/TestCase.php`, `tests/Feature/WelcomeTest.php`).
+- MIT license.
+

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "glueful/framework": "^1.2.0"
+    "glueful/framework": "^1.3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Introduced CHANGELOG.md to document project changes. Updated composer.json to require glueful/framework version ^1.3.0 for initial public release and new features.