### PR TITLE
Update framework to glueful/framework 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.1.0] - 2025-10-13 — Orion Compatibility
+
+Compatibility release aligning the skeleton with Glueful Framework 1.5.0.
+
+### Changed
+- Bump framework dependency to `glueful/framework ^1.5.0`.
+  - Gains Notifications DI provider (shared ChannelManager + NotificationDispatcher).
+  - Safer email verification/password reset flows via DI‑first wiring in the framework.
+
+### Notes
+- No code changes required in the skeleton. After updating, run:
+
+```bash
+composer update glueful/framework
+```
+
+
 ## [1.0.1] - 2025-10-11 — Maintenance
 
 Small developer‑experience improvements and alignment with framework 1.4.2 install flow. No breaking changes.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "glueful/framework": "^1.4.2"
+    "glueful/framework": "^1.5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Bump framework dependency to ^1.5.0 for Orion compatibility. Gains Notifications DI provider and safer email/password flows. No code changes required; update dependencies with composer.