### PR TITLE
Update glueful/framework to version 1.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "glueful/framework": "^1.6.1"
+    "glueful/framework": "^1.6.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Bumps the glueful/framework dependency from 1.6.1 to 1.6.2 in composer.json to include the latest fixes and improvements.