### PR TITLE
Bump Glueful Framework to v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.3.1] - 2025-10-21 — Canopus Alignment
+
+Compatibility release aligning the skeleton with Glueful Framework 1.7.1.
+
+### Changed
+- Bump framework dependency to `glueful/framework ^1.7.1`.
+  - Picks up the extension discovery/boot fix (framework now calls `ExtensionManager::discover()` before `::boot()`), ensuring enabled extensions load and their migrations are discovered by CLI commands.
+
+### Notes
+- No code changes required in the skeleton. After updating, run:
+
+```bash
+composer update glueful/framework
+```
+
+If you use extensions, `extensions:list`/`extensions:why` and `migrate:status` will now accurately reflect enabled providers and their migrations after boot.
+
 # [1.3.0] - 2025-10-18 — Procyon Alignment
 
 Compatibility release aligning the skeleton with Glueful Framework 1.7.0.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "glueful/framework": "^1.7.0"
+    "glueful/framework": "^1.7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update framework dependency to ^1.7.1 for compatibility with extension discovery/boot improvements. No code changes required; update ensures enabled extensions and migrations are properly detected by CLI commands.