### PR TITLE
Castor — Apache hardening + framework 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.3.2] - 2025-10-21 — Castor
+
+Compatibility release aligning the skeleton with Glueful Framework 1.7.2 and improving Apache defaults.
+
+### Changed
+- Bump framework dependency to `glueful/framework ^1.7.2`.
+  - Picks up extension route-loading resilience (`ServiceProvider::loadRoutesFrom()` idempotent + exception‑safe).
+  - Dev server logs are less noisy (PHP built‑in server access/startup lines no longer printed as errors).
+- Harden `public/.htaccess` for Apache deployments:
+  - Disable `MultiViews` and directory indexing.
+  - Preserve `Authorization` and `X-XSRF-Token` headers for PHP.
+  - Canonicalize trailing slashes when not a real directory.
+
+### Notes
+- For Nginx, apply equivalent rewrites and header forwarding in the server block.
+- After updating, run:
+
+```bash
+composer update glueful/framework
+```
+
 ## [1.3.1] - 2025-10-21 — Canopus Alignment
 
 Compatibility release aligning the skeleton with Glueful Framework 1.7.1.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "glueful/framework": "^1.7.1"
+    "glueful/framework": "^1.7.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,31 @@
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews -Indexes
+    </IfModule>
+
+    RewriteEngine On
+
+    # Preserve headers (auth, CSRF) for PHP
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    RewriteCond %{HTTP:x-xsrf-token} .
+    RewriteRule .* - [E=HTTP_X_XSRF_TOKEN:%{HTTP:X-XSRF-Token}]
+
+    # Serve existing files/directories directly
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^ - [L]
+
+    # Canonicalize trailing slashes (not a real directory)
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ %1 [L,R=301]
+
+    # Front controller
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [L]
+</IfModule>
+
+# Ensure index.php is the default
+DirectoryIndex index.php


### PR DESCRIPTION
## [1.3.2] - 2025-10-21 — Castor

Compatibility release aligning the skeleton with Glueful Framework 1.7.2 and improving Apache defaults.

### Changed
- Bump framework dependency to `glueful/framework ^1.7.2`.
  - Picks up extension route-loading resilience (`ServiceProvider::loadRoutesFrom()` idempotent + exception‑safe).
  - Dev server logs are less noisy (PHP built‑in server access/startup lines no longer printed as errors).
- Harden `public/.htaccess` for Apache deployments:
  - Disable `MultiViews` and directory indexing.
  - Preserve `Authorization` and `X-XSRF-Token` headers for PHP.
  - Canonicalize trailing slashes when not a real directory.

### Notes
- For Nginx, apply equivalent rewrites and header forwarding in the server block.
- After updating, run:

```bash
composer update glueful/framework
```