### PR TITLE
Add documentation config and update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 # --- OS / Misc ---
 .DS_Store
 *.log
+bootstrap/cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.5.1] - 2026-01-19 — Castor Alignment
+
+Compatibility release aligning the skeleton with Glueful Framework 1.9.1.
+
+### Added
+- `config/documentation.php` - Centralized OpenAPI/Swagger documentation settings including:
+  - API info, servers, and security schemes
+  - Output paths for generated documentation
+  - UI configuration for Scalar, Swagger UI, and Redoc
+
+### Changed
+- Bump framework dependency to `glueful/framework ^1.9.1`.
+  - New `--ui` option for `generate:openapi` command supporting Scalar, Swagger UI, and Redoc
+  - Refactored documentation system with `OpenApiGenerator`, `TableDefinitionGenerator`, and `DocumentationUIGenerator`
+  - PHPDoc parsing now uses `phpDocumentor/ReflectionDocBlock` for robustness
+  - New `Numeric` and `Regex` validation rules
+  - Symfony packages updated to ^7.4
+- Updated `.gitignore` to exclude `bootstrap/cache/` directory.
+
+### Notes
+- After updating, run:
+
+```bash
+composer update glueful/framework
+```
+
+- To generate API documentation with interactive UI:
+
+```bash
+php glueful generate:openapi --ui
+php glueful generate:openapi --ui=swagger-ui
+php glueful generate:openapi --ui=redoc
+```
+
 ## [1.5.0] - 2026-01-17 — Betelgeuse Alignment
 
 Compatibility release aligning the skeleton with Glueful Framework 1.9.0.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.9.0"
+    "glueful/framework": "^1.9.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/config/documentation.php
+++ b/config/documentation.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Documentation Generation Configuration
+ *
+ * Centralizes all settings for OpenAPI/Swagger documentation generation.
+ * Used by TableDefinitionGenerator, DocGenerator, CommentsDocGenerator, and OpenApiGenerator.
+ */
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Documentation Enabled
+    |--------------------------------------------------------------------------
+    |
+    | Controls whether API documentation is enabled. Automatically disabled
+    | in production for security unless explicitly enabled.
+    |
+    */
+    'enabled' => env('API_DOCS_ENABLED', env('APP_ENV') !== 'production'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenAPI Specification Version
+    |--------------------------------------------------------------------------
+    |
+    | The OpenAPI specification version to use for generated documentation.
+    | Supported: "3.0.0", "3.0.3", "3.1.0"
+    |
+    */
+    'openapi_version' => env('OPENAPI_VERSION', '3.0.0'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Information
+    |--------------------------------------------------------------------------
+    |
+    | Metadata about your API that appears in the generated documentation.
+    | These values populate the "info" section of the OpenAPI spec.
+    |
+    */
+    'info' => [
+        'title' => env('API_TITLE', env('APP_NAME', 'API Documentation')),
+        'description' => env('API_DESCRIPTION', 'Auto-generated API documentation'),
+        'version' => env('API_VERSION', '1.0.0'),
+        'contact' => [
+            'name' => env('API_CONTACT_NAME', ''),
+            'email' => env('API_CONTACT_EMAIL', ''),
+            'url' => env('API_CONTACT_URL', ''),
+        ],
+        'license' => [
+            'name' => env('API_LICENSE_NAME', ''),
+            'url' => env('API_LICENSE_URL', ''),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Define the server URLs that appear in the generated documentation.
+    | Multiple servers can be defined for different environments.
+    |
+    */
+    'servers' => [
+        [
+            'url' => env('API_SERVER_URL', env('APP_URL', 'http://localhost') . '/api'),
+            'description' => env('API_SERVER_DESCRIPTION', 'API Server'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Output Paths
+    |--------------------------------------------------------------------------
+    |
+    | Paths where generated documentation files are stored.
+    | All paths are relative to base_path() unless absolute.
+    |
+    */
+    'paths' => [
+        // Main documentation output directory
+        'output' => base_path('docs'),
+
+        // Final swagger.json file location
+        'swagger' => base_path('docs/swagger.json'),
+
+        // JSON definitions for database tables
+        'database_definitions' => base_path('docs/json-definitions/database'),
+
+        // JSON definitions for route-based documentation
+        'route_definitions' => base_path('docs/json-definitions/routes'),
+
+        // JSON definitions for extension documentation
+        'extension_definitions' => base_path('docs/json-definitions/extensions'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Source Paths
+    |--------------------------------------------------------------------------
+    |
+    | Paths to scan for routes when generating documentation.
+    | Extensions are discovered via Composer packages through ExtensionManager.
+    |
+    */
+    'sources' => [
+        // Directory containing route files
+        'routes' => base_path('routes'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Security Schemes
+    |--------------------------------------------------------------------------
+    |
+    | Default security schemes to include in the generated documentation.
+    | These define authentication methods for your API.
+    |
+    */
+    'security_schemes' => [
+        'BearerAuth' => [
+            'type' => 'http',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT',
+            'description' => 'JWT authentication token',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generation Options
+    |--------------------------------------------------------------------------
+    |
+    | Options that control how documentation is generated.
+    |
+    */
+    'options' => [
+        // Include database table schemas in documentation
+        'include_tables' => true,
+
+        // Include route-based documentation from PHPDoc comments
+        'include_routes' => true,
+
+        // Include extension documentation
+        'include_extensions' => true,
+
+        // Pretty print JSON output
+        'pretty_print' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Documentation UI
+    |--------------------------------------------------------------------------
+    |
+    | Settings for the interactive documentation UI.
+    | Supported: "scalar", "swagger-ui", "redoc"
+    |
+    */
+    'ui' => [
+        // Default UI to generate (scalar, swagger-ui, redoc)
+        'default' => env('API_DOCS_UI', 'scalar'),
+
+        // Output filename for the generated HTML
+        'filename' => 'index.html',
+
+        // Page title
+        'title' => env('API_DOCS_UI_TITLE', 'API Documentation'),
+
+        // Scalar-specific settings
+        'scalar' => [
+            'theme' => env('API_DOCS_THEME', 'purple'),
+            'dark_mode' => env('API_DOCS_DARK_MODE', true),
+            'hide_download_button' => false,
+            'hide_models' => false,
+            'default_open_all_tags' => false,
+        ],
+
+        // Swagger UI-specific settings
+        'swagger_ui' => [
+            'deep_linking' => true,
+            'display_request_duration' => true,
+            'filter' => true,
+        ],
+
+        // Redoc-specific settings
+        'redoc' => [
+            'expand_responses' => '200,201',
+            'hide_download_button' => false,
+            'theme' => [],
+        ],
+    ],
+];


### PR DESCRIPTION
This pull request introduces version 1.5.1 of the project, aligning it with Glueful Framework 1.9.1. The main focus is on enhancing and centralizing API documentation configuration, updating dependencies, and improving compatibility with the latest framework features.

**Documentation System Enhancements:**

* Added new `config/documentation.php` file to centralize all OpenAPI/Swagger documentation settings, including API info, server configuration, output paths, security schemes, and UI options for Scalar, Swagger UI, and Redoc.
* Refactored documentation generation to use new classes: `OpenApiGenerator`, `TableDefinitionGenerator`, and `DocumentationUIGenerator` for improved maintainability and extensibility.
* PHPDoc parsing now leverages `phpDocumentor/ReflectionDocBlock` for more robust documentation extraction.

**Framework and Dependency Updates:**

* Updated framework dependency in `composer.json` to require `glueful/framework ^1.9.1`, ensuring compatibility with the latest framework features.
* Symfony packages upgraded to version ^7.4.

**Validation and Miscellaneous Improvements:**

* Introduced new `Numeric` and `Regex` validation rules.
* Updated `.gitignore` to exclude the `bootstrap/cache/` directory.

**Developer Notes:**

* After updating, run `composer update glueful/framework` to ensure all dependencies are up to date.
* To generate API documentation with interactive UI, use the new `--ui` option with the `generate:openapi` command, supporting Scalar, Swagger UI, and Redoc.