### PR TITLE
Simplify API version and URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,17 +4,9 @@ APP_ENV=development
 # Note: Framework automatically sets APP_DEBUG=false when APP_ENV=production
 APP_DEBUG=true
 BASE_URL=http://localhost:8000
-API_BASE_URL=http://localhost:8000
-API_VERSION=v1
-API_VERSION_FULL=1.0.0
+API_VERSION=1
 # Note: Framework automatically disables API docs when APP_ENV=production for security
 API_DOCS_ENABLED=true
-
-# API Versioning
-# API_DEFAULT_VERSION=1
-# API_VERSION_STRATEGY=url_prefix  # url_prefix, header, query, accept
-# API_VERSION_STRICT=false
-# API_PREFIX=/api
 
 # Security Keys - IMPORTANT: Generate secure keys before production!
 # Use: php bin/glueful generate:key to create secure keys automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.6.1] - 2026-01-22 — Configuration Simplification
+
+Patch release simplifying environment configuration by consolidating URL and version variables.
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.19.1`.
+- **Simplified URL Configuration**: All URLs now derive from single `BASE_URL`
+  - Removed `API_BASE_URL` from `.env.example`
+- **Simplified Version Configuration**: Consolidated to single `API_VERSION`
+  - Removed `API_VERSION_FULL` — docs version derived automatically
+  - Removed `API_DEFAULT_VERSION` — use `API_VERSION` instead
+  - Changed format from `API_VERSION=v1` to `API_VERSION=1` (integer)
+- Updated `config/app.php`, `config/api.php`, `config/documentation.php` to use simplified variables
+
+### Migration
+
+Update your `.env` file:
+
+```diff
+- BASE_URL=http://localhost:8000
+- API_BASE_URL=http://localhost:8000
+- API_VERSION=v1
+- API_VERSION_FULL=1.0.0
++ BASE_URL=http://localhost:8000
++ API_VERSION=1
+```
+
+---
+
 ## [1.6.0] - 2026-01-22 — API Essentials
 
 Major release aligning the skeleton with Glueful Framework 1.19.0, bringing support for all Priority 3 API-specific features: API Versioning, Enhanced Rate Limiting, Webhooks System, and Search & Filtering DSL. This release completes the foundational API tooling needed for production-grade REST APIs.
@@ -15,12 +45,6 @@ Major release aligning the skeleton with Glueful Framework 1.19.0, bringing supp
   - `rate_limiting` — Tiered rate limiting with multiple algorithms (sliding, fixed, token bucket)
   - `webhooks` — Webhook delivery configuration with HMAC signatures and retry logic
   - `filtering` — Search & Filtering DSL configuration with operator controls
-
-- **.env.example** — New environment variables for all features:
-  - API versioning: `API_DEFAULT_VERSION`, `API_VERSION_STRATEGY`, `API_VERSION_STRICT`
-  - Rate limiting: `API_RATE_LIMITING_ENABLED`, `API_RATE_LIMIT_ALGORITHM`, `API_RATE_LIMIT_DEFAULT_TIER`
-  - Webhooks: `WEBHOOKS_ENABLED`, `WEBHOOKS_QUEUE`, `WEBHOOKS_TIMEOUT`, `WEBHOOKS_MAX_ATTEMPTS`
-  - Search: `API_SEARCH_DRIVER`, `ELASTICSEARCH_HOST`, `MEILISEARCH_HOST`, `MEILISEARCH_KEY`
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.19.0"
+    "glueful/framework": "^1.19.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/config/api.php
+++ b/config/api.php
@@ -39,7 +39,7 @@ return [
         | The default API version when none is specified in the request.
         |
         */
-        'default' => env('API_DEFAULT_VERSION', '1'),
+        'default' => env('API_VERSION', '1'),
 
         /*
         |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -19,11 +19,9 @@ return [
 
     // API Information
     'name' => env('APP_NAME', 'Glueful'),
-    'version_full' => env('API_VERSION_FULL', '1.0.0'),
-
     'urls' => [
         'base' => env('BASE_URL', 'http://localhost'),
-        'docs' => rtrim(env('BASE_URL', 'http://localhost'), '/') . '/api/' . env('API_VERSION', 'v1') . '/docs/',
+        'docs' => rtrim(env('BASE_URL', 'http://localhost'), '/') . '/api/v' . env('API_VERSION', '1') . '/docs/',
     ]
 
 ];

--- a/config/documentation.php
+++ b/config/documentation.php
@@ -48,7 +48,7 @@ return [
     'info' => [
         'title' => env('API_TITLE', env('APP_NAME', 'API Documentation')),
         'description' => env('API_DESCRIPTION', 'Auto-generated API documentation'),
-        'version' => env('API_VERSION', '1.0.0'),
+        'version' => env('API_VERSION', '1') . '.0.0',
         'contact' => [
             'name' => env('API_CONTACT_NAME', ''),
             'email' => env('API_CONTACT_EMAIL', ''),


### PR DESCRIPTION
Consolidates environment and config variables for API versioning and URLs. Removes redundant API version and base URL variables, updates config files to use a single API_VERSION integer, and bumps glueful/framework to 1.19.1. See CHANGELOG for migration details.