### PR TITLE
Bump glueful/framework to ^1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.13.1] - 2026-02-09 — Auth Provider Fix
+
+Patch release aligning with Glueful Framework 1.30.1.
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.30.1`
+
+### Framework Fixes Included
+
+- **JWTService context initialization**: `JWTService` context is now set before auth providers are initialized in `AuthBootstrap`, fixing potential null context errors during social and third-party auth provider registration
+
+### Notes
+
+After updating, run:
+
+```bash
+composer update glueful/framework
+```
+
+No breaking changes.
+
+---
+
 ## [1.13.0] - 2026-02-09 — Exception Handler Consolidation
 
 Release aligning the skeleton with Glueful Framework 1.30.0 (Diphda), featuring unified exception handling.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.30.0"
+    "glueful/framework": "^1.30.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update dependency to glueful/framework ^1.30.1 and add a CHANGELOG entry for v1.13.1. This aligns the skeleton with Framework 1.30.1 which fixes JWTService context initialization so auth providers are initialized with a valid context (avoiding null context errors during social and third-party auth provider registration). After pulling these changes, run: composer update glueful/framework. No breaking changes.