### PR TITLE
Update schema & bump glueful to v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.15.0] - 2026-02-11 — Schema Builder Callback API
+
+Release aligning the skeleton with Glueful Framework 1.32.0 (Fomalhaut), featuring the `alterTable` callback API.
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.32.0`
+- **Users table schema**: Removed `user_agent`, `ip_address`, `x_forwarded_for_ip_address`, and `last_login_date` columns from the `users` table in `database/migrations/001_CreateInitialSchema.php`. These fields belong in `auth_sessions`, not the users table. Added `updated_at` timestamp.
+
+### Framework Features Now Available
+
+This release includes features from Glueful Framework 1.32.0:
+
+#### Dual-Mode `alterTable` API
+- `alterTable()` now accepts an optional callback parameter, mirroring the `createTable` dual-mode pattern
+- Without a callback: returns a fluent `TableBuilder` for chaining (existing behavior unchanged)
+- With a callback: passes the builder to the callback, auto-executes the ALTER statements, and returns `$this` for schema-level chaining
+
+```php
+// Fluent mode (unchanged)
+$schema->alterTable('users')->addColumn('avatar', 'string')->execute();
+
+// Callback mode (new)
+$schema->alterTable('users', function ($table) {
+    $table->string('avatar')->nullable();
+    $table->index('email');
+});
+```
+
+#### ColumnBuilder Finalization Safety
+- Callback path calls `gc_collect_cycles()` before executing, ensuring `ColumnBuilder` destructors register columns via `finalizeColumn()` before the ALTER SQL is generated
+
+### Notes
+
+After updating, run:
+
+```bash
+composer update glueful/framework
+```
+
+No breaking changes. All existing schema builder usage continues to work unchanged.
+
+---
+
 ## [1.14.0] - 2026-02-09 — Context Propagation
 
 Release aligning the skeleton with Glueful Framework 1.31.0 (Enif), featuring centralized context propagation.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.31.0"
+    "glueful/framework": "^1.32.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/database/migrations/001_CreateInitialSchema.php
+++ b/database/migrations/001_CreateInitialSchema.php
@@ -56,12 +56,9 @@ class CreateInitialSchema implements MigrationInterface
             $table->string('email', 255);
             $table->string('password', 100)->nullable();
             $table->string('status', 20)->default('active');
-            $table->string('user_agent', 512)->nullable();
-            $table->string('ip_address', 40)->nullable();
-            $table->string('x_forwarded_for_ip_address', 40)->nullable();
-            $table->timestamp('last_login_date')->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->timestamp('created_at')->default('CURRENT_TIMESTAMP');
+            $table->timestamp('updated_at')->default('CURRENT_TIMESTAMP');
             $table->timestamp('deleted_at')->nullable();
 
             // Add indexes
@@ -114,7 +111,7 @@ class CreateInitialSchema implements MigrationInterface
 
             // Add indexes
             $table->unique('uuid');
-            $table->index('user_uuid');
+            $table->unique('user_uuid');
             $table->index('photo_uuid');
 
             // Add foreign keys


### PR DESCRIPTION
Align project with Glueful Framework ^1.32.0: update composer dependency and add release notes to CHANGELOG. Adjust database migration (001_CreateInitialSchema.php) by removing session-related columns (user_agent, ip_address, x_forwarded_for_ip_address, last_login_date) from the users table, adding an updated_at timestamp, and making user_uuid unique instead of a plain index. Run `composer update glueful/framework` after merging. No breaking changes expected.