### PR TITLE
Bump glueful/framework to ^1.33.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.32.0"
+    "glueful/framework": "^1.33.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Add CHANGELOG entry for 1.16.0 (Container-Enforced Request Resolution) documenting removal of fromGlobals fallbacks, memory-safety and long-running server fixes, silent fallback removal, and SessionStoreInterface addition; and bump glueful/framework dependency to ^1.33.0. After updating, run `composer update glueful/framework`.