### PR TITLE
Add 1.17.0 changelog, bump framework, update uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.33.0"
+    "glueful/framework": "^1.34.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/config/uploads.php
+++ b/config/uploads.php
@@ -16,7 +16,7 @@ return [
     'max_size' => env('UPLOADS_MAX_SIZE', 10 * 1024 * 1024),
 
     // Storage path prefix
-    'path_prefix' => env('UPLOADS_PATH_PREFIX', 'uploads'),
+    'path_prefix' => env('UPLOADS_PATH_PREFIX', ''),
 
     // Access control mode:
     // - true/'private': Auth required for upload AND retrieval


### PR DESCRIPTION
Add a new 1.17.0 changelog entry documenting the Hardened Auth Pipeline and framework upgrades. Bump glueful/framework requirement to ^1.34.0 in composer.json to pick up framework hardening and fixes. Adjust uploads config: set path_prefix default to an empty string instead of 'uploads'. After pulling these changes run composer update glueful/framework.