### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.23.0] - 2026-02-21 — Notification Delivery Orchestration
+
+Release aligning the skeleton with Glueful Framework 1.40.0 (Alnair), which adds notification split delivery, per-channel delivery tracking, DB-indexed idempotency, and provisioning error semantics.
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.40.0`
+- **`004_CreateNotificationSystemTables.php`**: Added `notification_deliveries` table for per-channel delivery state tracking (`notification_uuid`, `channel`, `status`, `attempt_count`, `last_error`, `last_attempt_at`, `sent_at`) with unique key on `(notification_uuid, channel)`. Added `idempotency_key` column with index to `notifications` table.
+
+### Framework Features Now Available
+
+This release includes features from Glueful Framework 1.40.0:
+
+#### Split Delivery API
+- `NotificationService::sendSplit()` provides first-class sync/async channel separation. `send()` supports `sync_channels`, `async_channels`, `channel_failure_policy` (`any_success`, `require_critical`, `all`), and `critical_channels`.
+
+#### Per-Channel Delivery Tracking
+- New `notification_deliveries` table and repository APIs track delivery lifecycle per channel. Async retries target only failed channels — already-sent channels are skipped.
+
+#### DB-Indexed Idempotency
+- Dedicated `notifications.idempotency_key` column with index replaces the previous `_meta` JSON scan. Channel-level idempotency via unique key on `(notification_uuid, channel)`.
+
+#### Provisioning Exception
+- `ProvisioningException` for account setup failures maps to HTTP 500 and `api` log channel, replacing misleading 401 responses.
+
+### Notes
+
+After updating, run:
+
+```bash
+composer update glueful/framework
+php glueful migrate:run
+```
+
+Non-backward-compatible changes to notification sending flow and response structure.
+
+---
+
 ## [1.22.0] - 2026-02-20 — Token/Session Reimplementation
 
 Release aligning the skeleton with Glueful Framework 1.39.0 (Menkent), which replaces the legacy token/session model with a security-first architecture.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.37.0"
+    "glueful/framework": "^1.38.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.38.0"
+    "glueful/framework": "^1.39.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.39.0"
+    "glueful/framework": "^1.40.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/database/migrations/001_CreateInitialSchema.php
+++ b/database/migrations/001_CreateInitialSchema.php
@@ -131,14 +131,12 @@ class CreateInitialSchema implements MigrationInterface
             $table->bigInteger('id')->unsigned()->primary()->autoIncrement();
             $table->string('uuid', 12);
             $table->string('user_uuid', 12);
-            $table->text('access_token');
-            $table->text('refresh_token')->nullable();
-            $table->text('token_fingerprint');
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
-            $table->timestamp('last_token_refresh')->nullable();
-            $table->timestamp('access_expires_at');
-            $table->timestamp('refresh_expires_at');
+            $table->timestamp('last_seen_at')->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamp('revoked_at')->nullable();
+            $table->integer('session_version')->default(1);
             $table->string('status', 20)->default('active');
             $table->timestamp('created_at')->default('CURRENT_TIMESTAMP');
             $table->timestamp('updated_at')->default('CURRENT_TIMESTAMP');
@@ -155,17 +153,6 @@ class CreateInitialSchema implements MigrationInterface
                 ->references('uuid')
                 ->on('users');
         });
-
-        // B-tree indexes for token lookups aligned with auth query patterns
-        $qb = $schema->getConnection()->query();
-        $qb->executeModification(
-            'CREATE INDEX IF NOT EXISTS idx_auth_sessions_refresh_status'
-            . ' ON auth_sessions (refresh_token, status);'
-        );
-        $qb->executeModification(
-            'CREATE INDEX IF NOT EXISTS idx_auth_sessions_access_status'
-            . ' ON auth_sessions (access_token, status);'
-        );
     }
 
     /**

--- a/database/migrations/001_CreateInitialSchema.php
+++ b/database/migrations/001_CreateInitialSchema.php
@@ -155,6 +155,17 @@ class CreateInitialSchema implements MigrationInterface
                 ->references('uuid')
                 ->on('users');
         });
+
+        // B-tree indexes for token lookups aligned with auth query patterns
+        $qb = $schema->getConnection()->query();
+        $qb->executeModification(
+            'CREATE INDEX IF NOT EXISTS idx_auth_sessions_refresh_status'
+            . ' ON auth_sessions (refresh_token, status);'
+        );
+        $qb->executeModification(
+            'CREATE INDEX IF NOT EXISTS idx_auth_sessions_access_status'
+            . ' ON auth_sessions (access_token, status);'
+        );
     }
 
     /**

--- a/database/migrations/008_CreateAuthRefreshTokensTable.php
+++ b/database/migrations/008_CreateAuthRefreshTokensTable.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Glueful\Database\Migrations;
+
+use Glueful\Database\Migrations\MigrationInterface;
+use Glueful\Database\Schema\Interfaces\SchemaBuilderInterface;
+
+/**
+ * Create auth_refresh_tokens table for hashed refresh-token storage and rotation.
+ */
+class CreateAuthRefreshTokensTable implements MigrationInterface
+{
+    public function up(SchemaBuilderInterface $schema): void
+    {
+        $schema->createTable('auth_refresh_tokens', function ($table) {
+            $table->bigInteger('id')->unsigned()->primary()->autoIncrement();
+            $table->string('uuid', 12);
+            $table->string('session_uuid', 12);
+            $table->string('user_uuid', 12);
+            $table->string('token_hash', 64);
+            $table->string('status', 20)->default('active');
+            $table->string('parent_uuid', 12)->nullable();
+            $table->string('replaced_by_uuid', 12)->nullable();
+            $table->timestamp('issued_at')->default('CURRENT_TIMESTAMP');
+            $table->timestamp('expires_at');
+            $table->timestamp('consumed_at')->nullable();
+            $table->timestamp('created_at')->default('CURRENT_TIMESTAMP');
+
+            $table->unique('uuid');
+            $table->unique('token_hash');
+            $table->index('session_uuid');
+            $table->index('user_uuid');
+            $table->index('status');
+            $table->index('expires_at');
+            $table->index('parent_uuid');
+
+            $table->foreign('session_uuid')
+                ->references('uuid')
+                ->on('auth_sessions')
+                ->restrictOnDelete();
+
+            $table->foreign('user_uuid')
+                ->references('uuid')
+                ->on('users')
+                ->restrictOnDelete();
+        });
+
+        // Session version is used for access-token invalidation.
+        $qb = $schema->getConnection()->query();
+        $qb->executeModification(
+            'ALTER TABLE auth_sessions ADD COLUMN IF NOT EXISTS session_version INTEGER DEFAULT 1;'
+        );
+    }
+
+    public function down(SchemaBuilderInterface $schema): void
+    {
+        $schema->dropTableIfExists('auth_refresh_tokens');
+    }
+
+    public function getDescription(): string
+    {
+        return 'Creates auth_refresh_tokens table for one-time refresh rotation and replay detection';
+    }
+}


### PR DESCRIPTION
This pull request introduces a major update to the authentication/session infrastructure, aligning the project with Glueful Framework 1.39.0. The legacy token/session model is replaced by a new security-first architecture, including hash-only refresh tokens, session versioning, and enhanced replay detection. The database schema is updated to support the new model, and a new migration is added for secure refresh token storage.

**Authentication/session model overhaul:**

* Updated `auth_sessions` table in `001_CreateInitialSchema.php` to remove legacy token columns (such as `access_token`, `refresh_token`, and related expiration/fingerprint fields) and add new fields for session versioning, expiration, revocation, and last-seen tracking.
* Added `008_CreateAuthRefreshTokensTable.php` migration, introducing the `auth_refresh_tokens` table for secure, hash-only refresh token storage with one-time rotation, replay detection, and token family lineage. This migration also ensures the `session_version` column exists in `auth_sessions` for backward compatibility.

**Dependency and changelog updates:**

* Bumped the `glueful/framework` dependency to `^1.39.0` in `composer.json` to leverage new framework features.
* Documented all changes, upgrade instructions, and breaking changes in `CHANGELOG.md`, including notes on session/token invalidation and required post-upgrade actions.