### PR TITLE
Bump glueful/framework to ^1.40.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.23.2] - 2026-02-21 — Config Merge Safe Dedup
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.40.2`
+
+### Framework Fixes Included
+
+- **Config merge safe dedup for nested lists**: `mergeConfig()` list dedup replaced `array_unique()` with hash-based dedup using `json_encode`/`serialize` for complex items. Fixes 500 errors on event-driven flows (e.g., comment creation) that dispatch through queue/webhook listeners loading merged config with nested array items like `queue.monitoring.alert_rules`.
+
+### Notes
+
+Patch release. No breaking changes.
+
+```bash
+composer update glueful/framework
+```
+
+---
+
 ## [1.23.1] - 2026-02-21 — Config Merge Fix
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.40.1"
+    "glueful/framework": "^1.40.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Add changelog entry for v1.23.2 describing a config merge safe-dedup fix (replacing array_unique with hash-based dedup for nested list items to prevent 500 errors in event-driven flows). Update composer.json to require glueful/framework ^1.40.2. Patch release with no breaking changes; run `composer update glueful/framework` to apply.