### PR TITLE
Bump glueful/framework to ^1.40.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.23.3] - 2026-02-21 — Mutation WHERE + Queue Config + Async Notification
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.40.3`
+
+### Framework Fixes Included
+
+- **Mutation WHERE operator support**: `WhereClause`, `UpdateBuilder`, and `DeleteBuilder` now handle `<`, `<=`, `>`, `>=`, `!=`, `LIKE`, `IN`, `IS NULL`, `IS NOT NULL` in UPDATE/DELETE queries instead of crashing on non-equality conditions.
+- **Queue Redis config string coercion**: `DriverRegistry` accepts numeric-string ints/ports and boolean-like strings from `.env`, fixing config rejection in production.
+- **Async notification best-effort**: `NotificationService::queueAsyncDispatch()` wrapped in try/catch so side-effect failures don't crash primary API operations.
+
+### Notes
+
+Patch release. No breaking changes.
+
+```bash
+composer update glueful/framework
+```
+
+---
+
 ## [1.23.2] - 2026-02-21 — Config Merge Safe Dedup
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.40.2"
+    "glueful/framework": "^1.40.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update dependency and release notes for patch 1.23.3. composer.json now requires glueful/framework ^1.40.3, and CHANGELOG.md adds an entry describing framework fixes: extended WHERE operator support in Mutation (UPDATE/DELETE), Redis queue config string coercion, and best-effort async notification dispatch (exceptions are caught). Patch release with no breaking changes; run composer update to apply.