### PR TITLE
Add profile-driven logging and bump framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,9 @@ UPLOADS_ENABLED=true
 # UPLOADS_STRIP_EXIF=true
 
 # Logging Configuration
+# Profile-driven defaults: development, staging, production, testing
+# If unset, profile falls back to APP_ENV.
+LOG_PROFILE=development
 
 # Framework Logging (Infrastructure/Protocol concerns)
 FRAMEWORK_LOGGING_ENABLED=true
@@ -222,12 +225,39 @@ HTTP_CLIENT_SLOW_THRESHOLD=5000
 
 # Application Logging (Business Logic)
 LOG_CHANNEL=app
+# Explicit override; when omitted, profile default is used.
 LOG_LEVEL=debug
 LOG_FILE_PATH=storage/logs
 LOG_TO_FILE=true
 LOG_TO_DB=false
 LOG_ROTATION_DAYS=30
 API_LOG_FILE=api_debug_
+
+# Database log retention (days)
+LOG_RETENTION_DAYS=30
+LOG_RETENTION_DEBUG_DAYS=7
+LOG_RETENTION_API_DAYS=14
+LOG_RETENTION_APP_DAYS=30
+LOG_RETENTION_FRAMEWORK_DAYS=30
+LOG_RETENTION_AUTH_DAYS=180
+LOG_RETENTION_SECURITY_DAYS=180
+LOG_RETENTION_ERROR_DAYS=180
+
+# Event System (core listeners / audit logging)
+EVENTS_ENABLED=true
+EVENTS_AUDIT_LOGGING=true
+EVENTS_SECURITY_MONITORING=true
+EVENTS_PERFORMANCE_MONITORING=true
+
+# Production baseline example:
+# APP_ENV=production
+# APP_DEBUG=false
+# LOG_PROFILE=production
+# LOG_TO_FILE=true
+# LOG_TO_DB=false            # set true only when queryable DB logs are required
+# LOG_LEVEL=warning
+# EVENTS_ENABLED=true
+# EVENTS_AUDIT_LOGGING=true
 
 # Scheduler queue routing
 SCHEDULE_QUEUE_CRITICAL=critical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.24.0] - 2026-03-03 — Profile-Driven Logging Bootstrap
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.41.0`
+- Updated `.env.example` with `LOG_PROFILE`, retention env keys, and production baseline example
+
+### Framework Changes Included
+
+- **Profile-driven logging bootstrap**: `config/logging.php` now resolves deterministic defaults from `LOG_PROFILE` (or `APP_ENV`) with built-in `development`, `staging`, `production`, and `testing` profiles. Explicit env vars override profile defaults.
+- **Production safety checks**: `system:check --production` now flags no durable log sink, disabled event/audit toggles, debug-level logging, and invalid retention values.
+- **Upsert column fix**: `InsertBuilder::buildUpsertQuery()` now passes column names to driver `upsert()` SQL builders, fixing PostgreSQL crash on null values.
+- **Audit toggle alignment**: Framework boot and `LogManager` now respect `EVENTS_ENABLED`, `EVENTS_AUDIT_LOGGING`, and `LOG_TO_FILE=false` correctly.
+
+### Upgrade Notes
+
+- **`LOG_TO_DB` default changed**: Previously defaulted to `true` when absent. Now defaults to `false` in all profiles. Add `LOG_TO_DB=true` to your `.env` if you require database logging.
+- New env vars recognized: `LOG_PROFILE`, `LOG_RETENTION_*_DAYS`. No action needed if unset.
+
+```bash
+composer update glueful/framework
+```
+
+---
+
 ## [1.23.4] - 2026-02-21 — WhereClause null fixes
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.40.4"
+    "glueful/framework": "^1.41.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,6 +1,84 @@
 <?php
 
 $root = dirname(__DIR__);
+$appEnv = (string) env('APP_ENV', 'development');
+$defaultProfile = match ($appEnv) {
+    'production' => 'production',
+    'staging' => 'staging',
+    'testing' => 'testing',
+    default => 'development',
+};
+$selectedProfile = (string) env('LOG_PROFILE', $defaultProfile);
+
+$profiles = [
+    'development' => [
+        'framework_level' => 'info',
+        'app_level' => 'debug',
+        'log_to_file' => true,
+        'log_to_db' => false,
+        'retention_default' => 30,
+        'retention' => [
+            'debug' => 7,
+            'api' => 14,
+            'app' => 30,
+            'framework' => 30,
+            'auth' => 180,
+            'security' => 180,
+            'error' => 180,
+        ],
+    ],
+    'staging' => [
+        'framework_level' => 'info',
+        'app_level' => 'info',
+        'log_to_file' => true,
+        'log_to_db' => false,
+        'retention_default' => 60,
+        'retention' => [
+            'debug' => 7,
+            'api' => 30,
+            'app' => 60,
+            'framework' => 60,
+            'auth' => 365,
+            'security' => 365,
+            'error' => 365,
+        ],
+    ],
+    'production' => [
+        'framework_level' => 'warning',
+        'app_level' => 'warning',
+        'log_to_file' => true,
+        'log_to_db' => false,
+        'retention_default' => 90,
+        'retention' => [
+            'debug' => 7,
+            'api' => 30,
+            'app' => 90,
+            'framework' => 90,
+            'auth' => 365,
+            'security' => 365,
+            'error' => 365,
+        ],
+    ],
+    'testing' => [
+        'framework_level' => 'warning',
+        'app_level' => 'warning',
+        'log_to_file' => false,
+        'log_to_db' => false,
+        'retention_default' => 7,
+        'retention' => [
+            'debug' => 1,
+            'api' => 1,
+            'app' => 1,
+            'framework' => 1,
+            'auth' => 7,
+            'security' => 7,
+            'error' => 7,
+        ],
+    ],
+];
+
+$profile = $profiles[$selectedProfile] ?? $profiles[$defaultProfile];
+$logDirectory = rtrim((string) env('LOG_FILE_PATH', $root . '/storage/logs/'), '/') . '/';
 
 /**
  * Logging Configuration
@@ -9,13 +87,15 @@ $root = dirname(__DIR__);
  * - Framework logs: HTTP protocol, exceptions, lifecycle, performance
  * - Application logs: Business logic, user actions, custom events
  */
-
-
 return [
+    'profile' => $selectedProfile,
+    'default_profile' => $defaultProfile,
+    'profiles' => $profiles,
+
     // Framework-level logging configuration
     'framework' => [
         'enabled' => env('FRAMEWORK_LOGGING_ENABLED', true),
-        'level' => env('FRAMEWORK_LOG_LEVEL', 'info'),
+        'level' => env('FRAMEWORK_LOG_LEVEL', $profile['framework_level']),
         'channel' => env('FRAMEWORK_LOG_CHANNEL', 'framework'),
 
         // Feature-specific toggles
@@ -47,19 +127,14 @@ return [
     // Application-level logging (developers configure)
     'application' => [
         'default_channel' => env('LOG_CHANNEL', 'app'),
-        'level' => env('LOG_LEVEL', match (env('APP_ENV')) {
-            'production' => 'error',
-            'staging' => 'warning',
-            default => 'debug'
-        }),
-        'log_to_file' => env('LOG_TO_FILE', true),
-        'log_to_db' => env('LOG_TO_DB', true),
-        'database_logging' => env('LOG_TO_DB', true), // Alias for backward compatibility
+        'level' => env('LOG_LEVEL', $profile['app_level']),
+        'log_to_file' => env('LOG_TO_FILE', $profile['log_to_file']),
+        'log_to_db' => env('LOG_TO_DB', $profile['log_to_db']),
     ],
 
     // File paths and rotation settings
     'paths' => [
-        'log_directory' => env('LOG_FILE_PATH', $root . '/storage/logs/'),
+        'log_directory' => $logDirectory,
         'api_log_file' => env('API_LOG_FILE', 'api_debug_') . date('Y-m-d') . '.log',
     ],
 
@@ -80,15 +155,15 @@ return [
     |
     */
     'retention' => [
-        'default' => env('LOG_RETENTION_DAYS', 90),
+        'default' => env('LOG_RETENTION_DAYS', $profile['retention_default']),
         'channels' => [
-            'debug' => env('LOG_RETENTION_DEBUG_DAYS', 7),
-            'api' => env('LOG_RETENTION_API_DAYS', 30),
-            'app' => env('LOG_RETENTION_APP_DAYS', 90),
-            'framework' => env('LOG_RETENTION_FRAMEWORK_DAYS', 90),
-            'auth' => env('LOG_RETENTION_AUTH_DAYS', 365),
-            'security' => env('LOG_RETENTION_SECURITY_DAYS', 365),
-            'error' => env('LOG_RETENTION_ERROR_DAYS', 365),
+            'debug' => env('LOG_RETENTION_DEBUG_DAYS', $profile['retention']['debug']),
+            'api' => env('LOG_RETENTION_API_DAYS', $profile['retention']['api']),
+            'app' => env('LOG_RETENTION_APP_DAYS', $profile['retention']['app']),
+            'framework' => env('LOG_RETENTION_FRAMEWORK_DAYS', $profile['retention']['framework']),
+            'auth' => env('LOG_RETENTION_AUTH_DAYS', $profile['retention']['auth']),
+            'security' => env('LOG_RETENTION_SECURITY_DAYS', $profile['retention']['security']),
+            'error' => env('LOG_RETENTION_ERROR_DAYS', $profile['retention']['error']),
         ],
     ],
 
@@ -96,31 +171,31 @@ return [
     'channels' => [
         'framework' => [
             'driver' => 'daily',
-            'path' => env('LOG_FILE_PATH', $root . '/storage/logs/') . 'framework.log',
-            'level' => env('FRAMEWORK_LOG_LEVEL', 'info'),
+            'path' => $logDirectory . 'framework.log',
+            'level' => env('FRAMEWORK_LOG_LEVEL', $profile['framework_level']),
             'days' => env('LOG_ROTATION_DAYS', 30),
         ],
         'app' => [
             'driver' => 'daily',
-            'path' => env('LOG_FILE_PATH', $root . '/storage/logs/') . 'app.log',
-            'level' => env('LOG_LEVEL', 'debug'),
+            'path' => $logDirectory . 'app.log',
+            'level' => env('LOG_LEVEL', $profile['app_level']),
             'days' => env('LOG_ROTATION_DAYS', 30),
         ],
         'api' => [
             'driver' => 'daily',
-            'path' => env('LOG_FILE_PATH', $root . '/storage/logs/') . 'api.log',
-            'level' => env('LOG_LEVEL', 'debug'),
+            'path' => $logDirectory . 'api.log',
+            'level' => env('LOG_LEVEL', $profile['app_level']),
             'days' => env('LOG_ROTATION_DAYS', 30),
         ],
         'error' => [
             'driver' => 'daily',
-            'path' => env('LOG_FILE_PATH', $root . '/storage/logs/') . 'error.log',
+            'path' => $logDirectory . 'error.log',
             'level' => 'error',
             'days' => env('LOG_ROTATION_DAYS', 30),
         ],
         'debug' => [
             'driver' => 'daily',
-            'path' => env('LOG_FILE_PATH', $root . '/storage/logs/') . 'debug.log',
+            'path' => $logDirectory . 'debug.log',
             'level' => 'debug',
             'days' => env('LOG_ROTATION_DAYS', 30),
         ]


### PR DESCRIPTION
Introduce profile-based logging defaults and retention controls. Updates .env.example with LOG_PROFILE, per-channel LOG_RETENTION_*_DAYS, event toggles, and a production baseline example. Replace ad-hoc logging behavior in config/logging.php with deterministic profiles (development, staging, production, testing), computed log directory, profile-driven levels/targets (log_to_file, log_to_db) and per-channel retention defaults; explicit env vars still override profile values. Change default LOG_TO_DB to false in profiles. Bump glueful/framework to ^1.41.0 and add a changelog entry for the Profile-Driven Logging bootstrap. Upgrade notes: add LOG_PROFILE or LOG_RETENTION_* if you need non-default behavior and run `composer update glueful/framework`.