### PR TITLE
Release 1.26.0 — Framework 1.43.0 (Production Hardening)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,14 @@ DB_POOLING_ENABLED=false
 # DB_PGSQL_SCHEMA=public
 # DB_PGSQL_SSL_MODE=prefer
 
+# ORM-aware N+1 query detection (since 1.43.0 / Dabih)
+# Modes: off | warn | strict | auto
+#   off     — detection disabled
+#   warn    — logs [GLUEFUL-N+1] via error_log() with per-(model, relation) dedupe
+#   strict  — throws LazyLoadingViolationException (use this in CI to fail tests on N+1)
+#   auto    — warn in development, off elsewhere
+DB_LAZY_LOADING_MODE=auto
+
 # Redis Configuration
 REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.26.0] - 2026-05-21 — Production Hardening
+
+### Added
+
+- **`database/migrations/009_CreateApiKeysTable.php`** — Schema migration for the framework's hardened API key system. Creates `api_keys` with columns for `uuid`, `user_id`, `name`, `key_prefix` (indexed), `key_hash` (`UNIQUE`), `scopes` (JSON), `allowed_ips` (JSON), `expires_at`, `rotated_from_id`, `revoked_at`, and timestamps. Run `php glueful migrate:run` after upgrading.
+- **`.env.example` entries for `DB_LAZY_LOADING_MODE`** — New env var mirroring the framework's N+1 detection feature.
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.43.0`.
+
+### Framework Changes Included
+
+- **ORM-aware N+1 query detection**: `PreventsLazyLoading` trait on `Model` flags lazy-loaded relations on members of a hydrated collection. Four modes (`off`/`warn`/`strict`/`auto`) configured via `DB_LAZY_LOADING_MODE`. See `docs/ORM/N_PLUS_ONE_DETECTION.md`.
+- **Driver-aware `$query->explain()`**: SQLite uses `EXPLAIN QUERY PLAN`; MySQL/PostgreSQL use `EXPLAIN`. New `Builder::explain()` on the ORM applies global scopes.
+- **Kubernetes-conventional health probes**: `GET /health/live`, `GET /health/ready`, `GET /health/startup`. Existing `/healthz` and `/ready` keep working.
+- **Hardened API keys**: Dedicated `api_keys` table with per-key scopes, CIDR allowlists, expiration, rotation with grace period, and environment-prefixed plaintext (`gf_live_*` / `gf_test_*`). New `#[RequireScope]` route attribute auto-attaches the `require_scope` middleware. CLI: `apikey:create|list|rotate|revoke`. See `docs/API_KEYS.md`.
+- **ORM bug fixes**: Property access routes to relations correctly; `??` triggers lazy-load instead of swallowing; child models inherit parent's `ApplicationContext`; eager loading no longer emits `WHERE x = NULL`.
+- **`ApiKeyAuthenticationProvider` is single-track**: The legacy `users.api_key` fallback is removed. `UserRepository::findByApiKey()` is also removed (zero callers verified).
+
+### Upgrade Notes
+
+- **Run the migration** — `php glueful migrate:run` to create the `api_keys` table. The new auth provider and `apikey:*` CLI commands both require it.
+- **No automatic data migration from `users.api_key`** — the canonical schema (`001_CreateInitialSchema.php`) never had that column. If you customized your schema to add one, use `php glueful apikey:create --user=<uuid> --name=<label>` or `ApiKeyService::create()` programmatically to migrate keys.
+- **`UserRepository::findByApiKey()` is gone.** Remove any external references.
+- **New env var (optional): `DB_LAZY_LOADING_MODE`.** Default `auto` (warn in dev, off in prod). Set `strict` in CI to fail tests on accidental N+1 patterns.
+
+```bash
+composer update glueful/framework
+php glueful migrate:run
+```
+
+---
+
 ## [1.25.0] - 2026-05-20 — OpenAPI Spec Excellence
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.42.0"
+    "glueful/framework": "^1.43.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/database/migrations/009_CreateApiKeysTable.php
+++ b/database/migrations/009_CreateApiKeysTable.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Glueful\Database\Migrations;
+
+use Glueful\Database\Migrations\MigrationInterface;
+use Glueful\Database\Schema\Interfaces\SchemaBuilderInterface;
+
+/**
+ * CreateApiKeysTable Migration
+ *
+ * Creates the api_keys table for hardened API key authentication.
+ * Supports scopes, IP allowlist, expiration, rotation grace period,
+ * and environment-prefixed keys (gf_live_* / gf_test_*).
+ *
+ * @package Glueful\Database\Migrations
+ */
+class CreateApiKeysTable implements MigrationInterface
+{
+    public function up(SchemaBuilderInterface $schema): void
+    {
+        if ($schema->hasTable('api_keys')) {
+            return;
+        }
+
+        $schema->createTable('api_keys', function ($table) {
+            $table->bigInteger('id')->primary()->autoIncrement();
+            $table->string('uuid', 12);
+            $table->string('user_id', 12);
+            $table->string('name', 255);
+            $table->string('key_prefix', 24);
+            $table->string('key_hash', 64);
+            $table->text('scopes')->nullable();
+            $table->text('allowed_ips')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->bigInteger('rotated_from_id')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->timestamp('created_at')->default('CURRENT_TIMESTAMP');
+            $table->timestamp('updated_at')->default('CURRENT_TIMESTAMP');
+
+            // Uniqueness + lookup indexes
+            $table->unique('uuid');
+            $table->unique('key_hash');
+            $table->index('user_id');
+            $table->index('key_prefix');
+        });
+    }
+
+    public function down(SchemaBuilderInterface $schema): void
+    {
+        $schema->dropTableIfExists('api_keys');
+    }
+
+    public function getDescription(): string
+    {
+        return 'Creates api_keys table for hardened API key authentication '
+            . '(scopes, IP allowlist, expiration, rotation grace period, '
+            . 'environment-prefixed keys).';
+    }
+}


### PR DESCRIPTION
## Summary

  Companion release to **`glueful/framework` 1.43.0 — Dabih** (Production Hardening). Ships the schema migration the framework needs (`009_CreateApiKeysTable.php`), bumps the framework
  constraint, and mirrors the one new env var into `.env.example`.

  The headline framework work is the ORM-aware N+1 detector, driver-aware `$query->explain()`, Kubernetes-conventional health probes, and a dedicated `api_keys` table with per-key scopes, IP
  allowlists, expiration, and rotation grace. See the framework PR for the full feature breakdown.

  ## Changes

  ### Added
  - **`database/migrations/009_CreateApiKeysTable.php`** — Schema for the framework's hardened API key system. Columns: `uuid` (12-char nanoid, unique), `user_id` (indexed), `name`, 
  `key_prefix` (indexed, not unique — used for O(1) lookup), `key_hash` (SHA-256 hex, `UNIQUE`), `scopes` (JSON nullable), `allowed_ips` (JSON nullable), `expires_at`, `rotated_from_id` 
  (self-reference for rotation lineage), `revoked_at`, timestamps. The new `ApiKeyAuthenticationProvider` and `apikey:*` CLI commands require this table.
  - **`.env.example`: `DB_LAZY_LOADING_MODE=auto`** — Mirrors the framework's new N+1 detection env var with an inline comment documenting the four modes (`off`/`warn`/`strict`/`auto`).

  ### Changed
  - **`composer.json`**: `glueful/framework` constraint bumped from `^1.42.0` to `^1.43.0`.

  ## Framework Changes Included

  Headline items consumers get for free with this upgrade:

  - **ORM-aware N+1 detection** — actionable warnings naming the model + relation (`User::posts lazy-loaded from a collection of 50, add ->with('posts')`). Configure via 
  `DB_LAZY_LOADING_MODE`; strict mode throws for CI enforcement.
  - **Driver-aware `$query->explain()` and `Builder::explain()`** — useful EXPLAIN output on SQLite (`EXPLAIN QUERY PLAN`) without changing how MySQL/PostgreSQL behave.
  - **Kubernetes-conventional health probes** — `GET /health/live`, `GET /health/ready`, `GET /health/startup` at the canonical paths orchestrators expect. Existing `/healthz` and `/ready` 
  keep working.
  - **Hardened API keys** — `gf_live_*` / `gf_test_*` plaintext, SHA-256 storage, per-key scopes (`#[RequireScope]` route attribute auto-attaches enforcement middleware), CIDR allowlists, 
  rotation grace. CLI: `apikey:create|list|rotate|revoke`. Full guide in `vendor/glueful/framework/docs/API_KEYS.md`.
  - **ORM bug fixes** — property access routes to relations correctly; `??` triggers lazy-load instead of swallowing; child models inherit parent's `ApplicationContext`; eager loading no 
  longer emits `WHERE x = NULL`.
  - **`ApiKeyAuthenticationProvider` is now single-track** — legacy `users.api_key` fallback removed; `UserRepository::findByApiKey()` removed (zero callers verified).

  ## Migration Notes

  1. **Update the framework**:
     ```bash
     composer update glueful/framework
     ```

  2. **Run the migration**:
     ```bash
     php glueful migrate:run
     ```
     Creates the `api_keys` table required by the new auth provider and CLI commands.

  3. **No automatic data migration** from `users.api_key`. The canonical `001_CreateInitialSchema.php` never had that column, so there's nothing to migrate by default. Custom installs that 
  added the column should mint replacement keys via `php glueful apikey:create --user=<uuid> --name=<label>` or `ApiKeyService::create()` programmatically.

  4. **`UserRepository::findByApiKey()` is removed** in the framework. Any app-level code calling it must be updated.

  5. **Optional env var: `DB_LAZY_LOADING_MODE`**. Default `auto` is safe (warns only in `APP_ENV=development`, off elsewhere). Worth setting to `strict` in CI to fail tests on N+1 patterns. 
  No action needed for production deployments unless you want detection on.

  ## Test Plan

  - [ ] `composer install` resolves `glueful/framework ^1.43.0` cleanly
  - [ ] `php glueful migrate:run` applies `009_CreateApiKeysTable.php` without errors
  - [ ] `php glueful migrate:rollback` drops the table cleanly
  - [ ] `php glueful migrate:status` lists `009_CreateApiKeysTable` as applied
  - [ ] `php glueful apikey:create --user=<existing-uuid> --name="Smoke test"` produces a usable plaintext key
  - [ ] `php glueful apikey:list --user=<uuid>` shows the new key with correct columns
  - [ ] `composer test` passes against the new framework version
  - [ ] `GET /health/live`, `/health/ready`, `/health/startup` respond with expected shapes

  ## Companion PRs

  - **`glueful/framework` 1.43.0 — Dabih**: the feature work — N+1 detection, EXPLAIN, health probes, API key hardening, ORM fixes
  - **`glueful/docs`**: release notes for 1.43.0 in `content/releases.md`