### PR TITLE
Release 1.28.0 — Framework 1.45.0 (The Second Factor)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,18 @@ DEFAULT_SECURITY_LEVEL=1
 TOKEN_SALT=
 JWT_ALGORITHM=HS256
 
+# Email two-factor authentication (opt-in; off by default).
+# When false, the /2fa/* routes are not registered and login is unchanged.
+# To enable: run the 010_AddTwoFactorEnabledToUsers migration, install
+# glueful/email-notification, then set this to true.
+TWO_FACTOR_ENABLED=false
+# Optional tunables (defaults shown):
+# TWO_FACTOR_PIN_LENGTH=6
+# TWO_FACTOR_PIN_TTL=300
+# TWO_FACTOR_CHALLENGE_TTL=300
+# TWO_FACTOR_DISABLE_FRESHNESS=300
+# TWO_FACTOR_TEMPLATE=two-factor-pin
+
 # CORS Configuration
 # Development: local origins prefilled for convenience
 # Production: set explicit domains; avoid '*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.28.0] - 2026-05-27 — The Second Factor
+
+### Added
+
+- **`database/migrations/010_AddTwoFactorEnabledToUsers.php`** — Adds the `users.two_factor_enabled` boolean column (default `false`) required by the framework's core email-PIN 2FA feature. Idempotent (`hasColumn()` guard). Run `php glueful migrate:run` after upgrading. Only needed if you intend to enable 2FA.
+- **`.env.example` entries for the `TWO_FACTOR_*` env vars** — `TWO_FACTOR_ENABLED` (default `false`) plus optional tunables (`TWO_FACTOR_PIN_LENGTH`, `TWO_FACTOR_PIN_TTL`, `TWO_FACTOR_CHALLENGE_TTL`, `TWO_FACTOR_DISABLE_FRESHNESS`, `TWO_FACTOR_TEMPLATE`), mirroring the framework's `config/auth.php`.
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.45.0`.
+
+### Framework Changes Included
+
+- **Core email-PIN 2FA (opt-in, off by default)**: `POST /auth/login` for an enrolled user returns a `challenge_token` and emails a 6-digit PIN; the client completes login at `POST /2fa/verify`. New `/2fa/enable|verify|disable` routes (registered only when `TWO_FACTOR_ENABLED=true`), `2fa:enable|disable|status` CLI, and a `config/auth.php` `two_factor` block. `/2fa/verify` re-validates the account before issuing a session and writes a session-scoped freshness marker that gates `/2fa/disable`. Requires `glueful/email-notification` for the email channel + `two-factor-pin` template.
+- **`selectRaw()` parameter bindings**: `QueryBuilder::selectRaw(string $expression, array $bindings = [])` binds positional `?` values; backward compatible. New `docs/SECURITY.md` documents the SQL-injection and XSS model.
+- **`AdminPermissionMiddleware` MFA cleanup**: removed the dead `X-MFA-Token` header path; `require_mfa` reads only the session handshake.
+
+### Upgrade Notes
+
+- **2FA is opt-in.** If you do not set `TWO_FACTOR_ENABLED=true`, this release is behavior-identical to 1.27.0 — the migration is optional and the `/2fa/*` routes are not registered. To enable: run the `010` migration, install `glueful/email-notification`, set `TWO_FACTOR_ENABLED=true`, and enroll users.
+- **New optional env vars.** See `.env.example`. All default to safe values that preserve current behavior.
+
+```bash
+composer update glueful/framework
+php glueful migrate:run   # only if enabling 2FA
+```
+
+---
+
 ## [1.27.0] - 2026-05-22 — Closing the Trust Gaps
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.44.0"
+    "glueful/framework": "^1.45.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Authentication Configuration
+ *
+ * Core email-PIN two-factor authentication (2FA). The feature is opt-in:
+ * `enabled` defaults to false, so a fresh install behaves exactly like a
+ * pre-2FA framework until TWO_FACTOR_ENABLED=true and the migration is run.
+ */
+
+return [
+    'two_factor' => [
+        // Master switch. When false, TwoFactorService::isEnabled() short-circuits
+        // before any DB read and the /2fa/* routes are not registered.
+        'enabled' => env('TWO_FACTOR_ENABLED', false),
+
+        // Number of digits in the emailed PIN.
+        'pin_length' => (int) env('TWO_FACTOR_PIN_LENGTH', 6),
+
+        // How long an emailed PIN remains valid (seconds).
+        'pin_ttl' => (int) env('TWO_FACTOR_PIN_TTL', 300),
+
+        // How long a challenge_token remains valid (seconds).
+        'challenge_ttl' => (int) env('TWO_FACTOR_CHALLENGE_TTL', 300),
+
+        // Notification template name (rendered by glueful/email-notification).
+        'template_name' => env('TWO_FACTOR_TEMPLATE', 'two-factor-pin'),
+
+        // How long after a 2FA login a session may call /2fa/disable without
+        // re-verifying (seconds). Session-scoped marker, not user-scoped.
+        'disable_freshness' => (int) env('TWO_FACTOR_DISABLE_FRESHNESS', 300),
+    ],
+];

--- a/database/migrations/010_AddTwoFactorEnabledToUsers.php
+++ b/database/migrations/010_AddTwoFactorEnabledToUsers.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Glueful\Database\Migrations;
+
+use Glueful\Database\Migrations\MigrationInterface;
+use Glueful\Database\Schema\Interfaces\SchemaBuilderInterface;
+
+/**
+ * AddTwoFactorEnabledToUsers Migration
+ *
+ * Adds the two_factor_enabled boolean column to the users table for the
+ * core email-PIN 2FA feature. Idempotent: re-running after a manual
+ * ALTER TABLE that already added the column is a no-op.
+ *
+ * Uses the no-callback alterTable() form so it works against both the
+ * released framework (1.44.x) and newer versions — the callback form is a
+ * newer addition. Column registration happens via ColumnBuilder::__destruct,
+ * so we force collection before flushing (mirrors the framework's own
+ * createTable() callback handling).
+ *
+ * @package Glueful\Database\Migrations
+ */
+class AddTwoFactorEnabledToUsers implements MigrationInterface
+{
+    public function up(SchemaBuilderInterface $schema): void
+    {
+        if ($schema->hasColumn('users', 'two_factor_enabled')) {
+            return;
+        }
+
+        $table = $schema->alterTable('users');
+        $table->boolean('two_factor_enabled')->notNull()->default(false);
+
+        // ColumnBuilder registers its column on __destruct; force it before
+        // the alteration is generated so the ADD COLUMN statement is emitted.
+        gc_collect_cycles();
+
+        $table->execute();   // generate + queue the ALTER TABLE ADD COLUMN
+        $schema->execute();  // flush pending SQL to the database
+    }
+
+    public function down(SchemaBuilderInterface $schema): void
+    {
+        if (!$schema->hasColumn('users', 'two_factor_enabled')) {
+            return;
+        }
+
+        // Schema-level helper alters + executes in one call.
+        $schema->dropColumn('users', 'two_factor_enabled');
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds two_factor_enabled boolean column to users for the core email-PIN 2FA feature.';
+    }
+}


### PR DESCRIPTION
Body:
  ## Summary
  
  Tracks framework **1.45.0 "Fomalhaut"**.
  
  - Bumps `glueful/framework` constraint to `^1.45.0`.
  - Adds `database/migrations/010_AddTwoFactorEnabledToUsers.php` — the `users.two_factor_enabled` boolean column (default `false`)
  required by the framework's core email-PIN 2FA. Idempotent (`hasColumn()` guard). **Only needed if enabling 2FA.**
  - Adds `TWO_FACTOR_ENABLED` (default `false`) + optional tunables to `.env.example`.
  
  ## Upgrade Notes
  
  - **2FA is opt-in.** Without `TWO_FACTOR_ENABLED=true`, this is behavior-identical to 1.27.0 — the migration is optional and
  `/2fa/*` routes are not registered.
  - To enable: run the `010` migration, install `glueful/email-notification`, set `TWO_FACTOR_ENABLED=true`, enroll users.
  
  ## Test plan
  
  ```bash
  composer update glueful/framework
  php glueful migrate:run   # only if enabling 2FA