### PR TITLE
Release 1.29.0 — Framework 1.46.0 (Fluent Query Caching)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.29.0] - 2026-05-28 — Fluent Query Caching
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.46.0`.
+
+### Framework Changes Included
+
+- **Fluent query result caching — `QueryBuilder::cache(?int $ttl = null, array $tags = [])`**: The fluent cache method now actually caches read queries (`get`/`first`/`count`/`max`) via `QueryCacheService`, with automatic per-table tags plus any caller-supplied `$tags` for targeted invalidation. Previously it was a silent no-op. Per-query (no global toggle), backward compatible, degrades to uncached if no cache backend is configured.
+- **Framework-wide PHPStan level-8 hardening (initiative kickoff)**: Internal typing fixes in the query-binding path (behavior-preserving); full `~914`-error level-8 gap catalogued in the framework's `docs/LEVEL8_TYPING_DEBT.md`. CI gate remains level 6.
+
+### Upgrade Notes
+
+- **No action required.** Framework-only release — no migrations, no env vars, no skeleton-side changes. `composer update` is sufficient.
+- **`->cache()` semantics changed from "no-op" to "actually caches"** on the framework side. If application code calls `->cache(ttl)` expecting nothing to happen, it'll now cache. The cache key is `query+params` (no auth/context scoping); make sure cached queries don't return user-scoped rows without a discriminator in the SQL.
+
+```bash
+composer update glueful/framework
+```
+
+---
+
 ## [1.28.0] - 2026-05-27 — The Second Factor
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.45.0"
+    "glueful/framework": "^1.46.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Body:
  ## Summary
  
  Tracks framework **1.46.0 "Gienah"**.
  
  - Bumps `glueful/framework` constraint to `^1.46.0`.
  - **No skeleton-side code changes** — no migration, no env var. The release pairing is maintained for the explicit
  supported-version signal and consistent release feed.
  
  ## Framework changes included
  
  - **`QueryBuilder::cache(?int $ttl = null, array $tags = [])` actually caches now** — wired through to `QueryCacheService` with
  automatic per-table tags plus caller-supplied invalidation tags. Previously a silent no-op. 
  - **PHPStan level-8 hardening (initiative kickoff)** — internal typing fixes in the query-binding path; full ~914-error gap
  catalogued in the framework's `docs/LEVEL8_TYPING_DEBT.md`. CI gate stays at level 6.
  
  ## Upgrade Notes
  
  - **No action required.** `composer update` is sufficient.
  - **`->cache()` now caches.** If app code calls it expecting nothing to happen, it'll now cache. Cache key is `query+params` — make
   sure cached queries don't return user-scoped rows without a discriminator in the SQL.
   
  ```bash
  composer update glueful/framework