### PR TITLE
Release 1.30.0 — Extension System Re-Architecture (framework 1.47.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.30.0] - 2026-05-30 — Extension System Re-Architecture
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.47.0`.
+- **Migrated `config/extensions.php` to the single-key model** — a single `enabled` array of plain string FQCNs (no `::class`, no `only` / `dev_only` / `disabled` / `local_path` / `scan_composer`). Ships empty (no extensions enabled by default).
+- **Migrated `config/serviceproviders.php` to the single-key model** — `enabled` now holds the app's own providers as string FQCNs (`'App\\Providers\\AppServiceProvider'`).
+
+### Framework Changes Included
+
+- **Extension System Re-Architecture**: Composer-only discovery + a single `enabled` allow-list + a pure resolver that validates (missing provider/dependency, framework-version mismatch, cycle) and topologically orders providers. `extensions:enable|disable` validate before writing and recompile; `extensions:list` shows state (`✓` / `○` / `⚠`); `extensions:cache` is strict; `create:extension` scaffolds a Composer package + path repository. `ProviderLocator`, the local-folder scan, runtime PSR-4 registration, and `extensions:why` are removed. Adds `composer/semver`.
+
+### Upgrade Notes
+
+- **Breaking config change.** If you customized `config/extensions.php` / `config/serviceproviders.php`, convert them to the single `enabled` list of plain string FQCNs; map old keys per the framework's `docs/EXTENSIONS_UPGRADE.md`.
+- **Run `composer update`** so the new `composer/semver` dependency installs (the resolver fatals at boot without it).
+- **Enable extensions explicitly** (`php glueful extensions:enable <name>`) and **run `php glueful extensions:cache` in production** — installing a package no longer auto-loads it, and production boots only from the compiled manifest.
+
+```bash
+composer update glueful/framework
+php glueful extensions:cache   # required in production
+```
+
+---
+
 ## [1.29.0] - 2026-05-28 — Fluent Query Caching
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.46.0"
+    "glueful/framework": "^1.47.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/config/extensions.php
+++ b/config/extensions.php
@@ -1,94 +1,22 @@
 <?php
 
+/**
+ * Extensions
+ *
+ * Composer discovers installed `glueful-extension` packages (see their
+ * extra.glueful.provider). This file is the single activation allow-list:
+ * an installed extension does nothing until its provider FQCN appears below.
+ *
+ * - Entries are plain string FQCNs (no ::class) so `php glueful extensions:enable|disable`
+ *   can edit this list safely. Do not use conditionals/function calls here.
+ * - Order is preserved; dependencies are reordered automatically.
+ * - Empty = nothing loads. To kill everything fast, set `enabled => []`.
+ *
+ * Manage with: php glueful extensions:list | enable <name> | disable <name> | cache
+ */
+
 return [
-     /*
-    |--------------------------------------------------------------------------
-    | Exclusive Allow-List Mode
-    |--------------------------------------------------------------------------
-    |
-    | When 'only' is set, ONLY these providers load. Nothing else.
-    | This overrides all other discovery methods for maximum security.
-    |
-    */
-    // 'only' => [
-    // Core business logic
-    //     'App\\Banking\\CoreBankingProvider',
-    //     'App\\Banking\\TransactionProvider',
-    //     'App\\Banking\\ComplianceProvider',
-
-    // Approved third-party
-    //     'Vendor\\Audit\\AuditProvider',
-    //     'Vendor\\Encryption\\FIPSProvider',
-
-    // NOTHING else can load - no auto-discovery
-    // ],
-
-    // Note: 'enabled', 'disabled', 'dev_only' are ignored when 'only' is set
-    /*
-    |--------------------------------------------------------------------------
-    | Enabled Extensions
-    |--------------------------------------------------------------------------
-    |
-    | List of extension service providers to load. These are loaded
-    | in the order specified. Overall discovery order:
-    | 1) enabled, 2) dev_only (non-prod), 3) local dev, 4) composer.
-    |
-    */
     'enabled' => [
-        // Core extensions
-        // Glueful\Blog\BlogServiceProvider::class,
-        // Glueful\Shop\ShopServiceProvider::class,
-
-        // Third-party
-        // Vendor\Analytics\AnalyticsServiceProvider::class,
+        // 'Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider',
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Development Extensions
-    |--------------------------------------------------------------------------
-    |
-    | Extensions only loaded in non-production environments.
-    |
-    */
-    'dev_only' => [
-        // Glueful\Debug\DebugServiceProvider::class,
-        // Glueful\Profiler\ProfilerServiceProvider::class,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Disabled Extensions (Blacklist)
-    |--------------------------------------------------------------------------
-    |
-    | Block specific extensions even if discovered. Useful for temporarily
-    | disabling problematic extensions during development.
-    |
-    */
-    'disabled' => [
-        // Example: Temporarily disable broken extension
-        // Vendor\Broken\BrokenServiceProvider::class,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Local Extensions Path
-    |--------------------------------------------------------------------------
-    |
-    | Path to scan for local extensions during development.
-    | Set to null to disable local extension scanning.
-    |
-    */
-    'local_path' => env('APP_ENV') === 'production' ? null : 'extensions',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Composer Package Scanning
-    |--------------------------------------------------------------------------
-    |
-    | Whether to scan Composer packages for glueful-extension types.
-    | Set to false to disable Composer scanning (for troubleshooting).
-    |
-    */
-    'scan_composer' => true,
 ];

--- a/config/serviceproviders.php
+++ b/config/serviceproviders.php
@@ -1,54 +1,16 @@
 <?php
 
+/**
+ * Application Service Providers
+ *
+ * The application's own service providers, loaded in declared order. These are
+ * app-local classes (not composer-discovered extensions) and are always loaded.
+ * Use string FQCNs (no ::class) so tooling can edit the list safely.
+ */
+
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Exclusive Allow-List Mode (App Providers)
-    |--------------------------------------------------------------------------
-    |
-    | When 'only' is set, ONLY these application service providers load.
-    | This does not include vendor extensions; set this to strictly control
-    | which first-party providers are allowed to load.
-    |
-    */
-    // 'only' => [
-    //     App\Core\CoreProvider::class,
-    //     App\Features\Payments\PaymentsProvider::class,
-    // ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Enabled App Providers
-    |--------------------------------------------------------------------------
-    |
-    | First-party providers loaded in all environments (order preserved).
-    |
-    */
     'enabled' => [
-        App\Providers\AppServiceProvider::class,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Development-Only App Providers
-    |--------------------------------------------------------------------------
-    |
-    | App providers loaded only in non-production environments.
-    |
-    */
-    'dev_only' => [
-        // App\Providers\DevToolsProvider::class,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Disabled App Providers
-    |--------------------------------------------------------------------------
-    |
-    | Block specific application providers from being loaded.
-    |
-    */
-    'disabled' => [
-        // App\Legacy\OldProvider::class,
+        'App\\Providers\\AppServiceProvider',
+        // 'App\\Providers\\EventServiceProvider',
     ],
 ];


### PR DESCRIPTION
- Bump glueful/framework to ^1.47.0.
- Migrate config/extensions.php and config/serviceproviders.php to the single `enabled` model (plain string FQCNs; no ::class / only / dev_only / disabled / local_path / scan_composer). Ships with no extensions enabled by default.

Run `composer update glueful/framework` (new composer/semver dep) and, in production, `php glueful extensions:cache`. See the framework's docs/EXTENSIONS_UPGRADE.md.