### PR TITLE
Release 1.31.0 — Framework 1.48.0 (Router Verb Completeness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.31.0] - 2026-05-31 — Router Verb Completeness
+
+### Changed
+
+- Bump framework dependency to `glueful/framework ^1.48.0` (the previous `^1.47.0` already permitted 1.48.0; bumped for clarity).
+
+### Framework Changes Included
+
+- **First-class `PATCH` and `OPTIONS` routing verbs**: New `$router->patch()` / `$router->options()` shortcuts and `#[Patch]` / `#[Options]` attributes; the `#[Route(methods: [...])]` array form now accepts `PATCH`, `OPTIONS` and `HEAD`. Both verbs were previously unreachable through the public routing API.
+- **Explicit `OPTIONS` routes beat auto-CORS**: an explicitly registered `OPTIONS` route now runs its own handler; automatic CORS preflight (204 + `Allow`) remains the default when none is registered.
+- **Route precedence documented and pinned** (static > dynamic; literal first segment > parameter first segment; registration order within a group).
+
+### Upgrade Notes
+
+- **No action required.** Framework-only release — no migrations, no env vars, no skeleton-side changes. `composer update` is sufficient.
+
+```bash
+composer update glueful/framework
+```
+
+---
+
 ## [1.30.0] - 2026-05-30 — Extension System Re-Architecture
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/framework": "^1.47.0"
+    "glueful/framework": "^1.48.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
## Summary
  
  Tracks framework **1.48.0 "Imai"**. Framework-only release — **no action
  required** beyond `composer update`.
  
  ## What changed
  
  - Bump `glueful/framework` constraint `^1.47.0` → `^1.48.0` (the previous
    constraint already permitted 1.48.0; bumped for clarity). 
  - Add `[1.31.0]` changelog entry summarizing the included framework changes.
  
  ## Framework changes included
  
  - First-class `PATCH`/`OPTIONS` routing verbs (`$router->patch()`/`options()`,
    `#[Patch]`/`#[Options]`, and `PATCH`/`OPTIONS`/`HEAD` in the `#[Route(methods:)]`
    form).
  - Explicit `OPTIONS` routes now run their own handler instead of being shadowed
    by automatic CORS preflight.
  - Route-precedence model documented and pinned with tests.
  
  ## Upgrade notes
  
  No migrations, no env vars, no skeleton-side code changes. `composer update` is
  sufficient.
  
  ## Files
  - `composer.json` — framework constraint bump
  - `CHANGELOG.md` — `[1.31.0]` entry