### PR TITLE
Release 1.34.0 — RBAC Opt-In & Mail Transport Notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,11 @@ NOTIFICATIONS_QUEUE_TIMEOUT=60
 NOTIFICATIONS_QUEUE_MAX_JOBS=1000
 
 # Email Configuration
+# SMTP works out of the box (symfony/mailer ships with the framework) — just fill in the
+# settings below. For an API transport (Postmark, Mailgun, Amazon SES, SendGrid, Brevo),
+# install the matching package — e.g. `composer require symfony/postmark-mailer` — then set
+# MAIL_MAILER / the mailer DSN accordingly. See glueful/email-notification's README for
+# per-provider setup.
 MAIL_MAILER=smtp
 MAIL_HOST=your_smtp_host
 MAIL_USERNAME=your_smtp_username

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.34.0] - 2026-06-05 — RBAC Opt-In & Mail Transport Notes
+
+### Changed
+
+- **RBAC (`glueful/aegis`) is now fully opt-in.** It's no longer a bundled `require-dev` dependency, and the `repositories` path-repo block was dropped entirely — the skeleton ships **no** `repositories`. Enable RBAC only when you need permission-gated features: `composer require glueful/aegis` (see README → "Identity, Accounts & RBAC").
+- Bumped **`glueful/email-notification` → `^1.7.0`** (Framework 1.50 compatibility: drops a dead event listener that referenced a removed framework interface; raises its minimum framework to `>=1.50.1`).
+
+### Documentation
+
+- **Mail transport guidance** in `.env.example`: SMTP works out of the box (the framework ships `symfony/mailer`); for an API transport (Postmark, Mailgun, Amazon SES, SendGrid, Brevo) install the matching `symfony/<provider>-mailer` package and set `MAIL_MAILER` / the DSN. Points to `glueful/email-notification`'s README for per-provider setup.
+
+### Upgrade Notes
+
+- **No action required.** RBAC was already disabled by default; this only removes the bundled (dev-only) dependency and the local path repo from the template. To add roles/permissions: `composer require glueful/aegis`, enable `AegisServiceProvider` in `config/extensions.php`, run migrations, then `php glueful aegis:bootstrap-admin --user=<uuid-or-email>`.
+
+---
+
 ## [1.33.0] - 2026-06-05 — Slim Skeleton & First-Party Identity
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,13 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/email-notification": "^1.6.0",
+    "glueful/email-notification": "^1.7.0",
     "glueful/framework": "^1.50.1",
     "glueful/users": "^1.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",
-    "squizlabs/php_codesniffer": "^3.6",
-    "glueful/aegis": "@dev"
+    "squizlabs/php_codesniffer": "^3.6"
   },
   "autoload": {
     "psr-4": {
@@ -58,9 +57,6 @@
     "sort-packages": true,
     "optimize-autoloader": true
   },
-  "repositories": [
-    { "type": "path", "url": "../extensions/aegis", "options": { "symlink": true } }
-  ],
   "minimum-stability": "stable",
   "prefer-stable": true
 }


### PR DESCRIPTION
## Summary
  
  Small follow-up to 1.33.0: makes RBAC a true opt-in (the skeleton bundles no RBAC),
  moves `glueful/email-notification` to the framework-1.50-compatible `^1.7.0`, and
  documents mail transport setup. No runtime behavior change to a fresh scaffold.
  
  ## Changes
  
  - **RBAC (`glueful/aegis`) is now fully opt-in.** Removed from `require-dev` and the
    `repositories` path-repo block dropped entirely — the skeleton ships **no**
    `repositories`. Add it on demand: `composer require glueful/aegis` (see README →
    "Identity, Accounts & RBAC").
  - **Bumped `glueful/email-notification` → `^1.7.0`** — its Framework-1.50 compatibility
    release (drops a dead event listener that referenced a removed framework interface;
    raises its own minimum framework to `>=1.50.1`).
  - **Mail transport guidance** in `.env.example`: SMTP works out of the box (the
    framework ships `symfony/mailer`); API transports (Postmark/Mailgun/SES/SendGrid/Brevo)
    need the matching `symfony/<provider>-mailer` package — points to
    `glueful/email-notification`'s README.
    
  ## Testing
  
  - `composer update glueful/email-notification` → resolves **v1.7.0** cleanly (no advisories).
  - `composer test` → **3/3** passing.
  
  ## Upgrade Notes
  
  - **No action required.** RBAC was already disabled by default; this just removes the
    bundled (dev-only) dependency and the local path repo from the template. To add 
    roles/permissions: `composer require glueful/aegis`, enable `AegisServiceProvider` in
    `config/extensions.php`, run migrations, then
    `php glueful aegis:bootstrap-admin --user=<uuid-or-email>`.

  ## Commits

  - `chore` RBAC fully opt-in + bump `glueful/email-notification ^1.7.0`
  - `docs` note SMTP default + API mail-transport packages in `.env.example`
  - `Release 1.34.0`
