### PR TITLE
Release 1.36.1 — Framework 1.53.0 Nunki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [1.36.1] - 2026-06-08 — Framework 1.53.0 Nunki
+
+### Changed
+
+- Bumped **`glueful/framework` → `^1.53.0`**. The 1.53.0 (Nunki) release adds two chainable database
+  extension seams (`QueryExecutor::addQueryInterceptor()` and `Connection::addTableHook()`, both no-ops
+  unless an extension registers a hook) and fixes three bugs: the `SecureSerializer` namespace-wildcard /
+  `C:` allowlist (queue job deserialization), table-qualified WHERE columns on `UPDATE`/`DELETE`, and
+  `Connection::class` container resolution (so `db()` / `app($ctx, Connection::class)` resolve out of the
+  box — a latent bug the skeleton shared). The previous `^1.52.0` constraint already permitted 1.53.0; the
+  bump to `^1.53.0` is for clarity. See the framework release notes for detail.
+
+### Upgrade Notes
+
+- **No action required for the skeleton.** `composer update glueful/framework` picks up 1.53.0. No new env
+  vars, no migrations, no config changes. **Backward-compatible for the skeleton** — standard `O:` queue
+  jobs, scoping, and DI are unchanged. One underlying framework change *tightens* `C:` / `Serializable`
+  deserialization validation (previously unchecked `C:` payloads are now allowlist-validated, like `O:`
+  objects); this is a security fix and **does not affect standard `O:` queue jobs** (the `Serializable` /
+  `C:` form is deprecated since PHP 8.1 and effectively unused in app jobs).
+
+---
+
 ## [1.36.0] - 2026-06-07 — Framework 1.52.0 Mizar
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.8.0",
-    "glueful/framework": "^1.52.0",
+    "glueful/framework": "^1.53.0",
     "glueful/media": "^1.0.0",
     "glueful/users": "^1.0.0"
   },


### PR DESCRIPTION
## Summary
  
  Patch release: target **`glueful/framework ^1.53.0`** (Nunki). No skeleton code,
  config, or env changes — this is a dependency constraint bump that brings the
  framework's new chainable DB extension seams and three bug fixes into the skeleton.
  
  Framework 1.53.0 (backward-compatible) adds:
  - **Two chainable DB extension seams** — `QueryExecutor::addQueryInterceptor()` and
    `Connection::addTableHook()` (both no-ops unless an extension registers a hook).
  - **Three fixes** — `SecureSerializer` namespace-wildcard / `C:` allowlist (queue job
    deserialization), table-qualified WHERE columns on `UPDATE`/`DELETE`, and
    `Connection::class` container resolution (so `db()` / `app($ctx, Connection::class)`
    resolve out of the box — a latent bug the skeleton shared).
    
  ## Changes
  - `composer.json` — `glueful/framework` `^1.52.0` → `^1.53.0` (the old constraint
    already permitted 1.53.0; bumped for clarity)
  - `CHANGELOG.md` — `[1.36.1]` entry
  
  ## Compatibility
  **Backward-compatible for the skeleton** — standard `O:` queue jobs, scoping, and DI are
  unchanged. One underlying framework change *tightens* `C:` / `Serializable` deserialization
  validation (previously-unchecked `C:` payloads are now allowlist-validated, like `O:`
  objects); this is a security fix and **does not affect standard `O:` queue jobs** (the
  `Serializable` / `C:` form is deprecated since PHP 8.1 and effectively unused in app jobs).
  
  ## Test Plan
  - [x] `composer update glueful/framework` resolves **published `v1.53.0`** from packagist
  - [x] Skeleton suite green (3 tests, 15 assertions) against the published framework
  - [x] Boots clean — `extensions:list` shows the three bundled extensions; no behavior change
  - [x] No new env vars, no migrations, no config changes

  ## Upgrade Notes
  **No action required.** `composer update glueful/framework` picks up 1.53.0.