### PR TITLE
Bump glueful/framework to ^1.61.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.61.0",
+    "glueful/framework": "^1.61.1",
     "glueful/media": "^1.1.0",
     "glueful/users": "^1.1.1"
   },


### PR DESCRIPTION
Update composer.json to require glueful/framework ^1.61.1 (was ^1.61.0) to pick up the latest patch release with bug fixes and minor improvements. Run composer update to refresh composer.lock and install the updated dependency.