### PR TITLE
Bump glueful/users to ^2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "glueful/email-notification": "^1.10.0",
     "glueful/framework": "^1.61.1",
     "glueful/media": "^1.1.0",
-    "glueful/users": "^1.1.1"
+    "glueful/users": "^2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update glueful/users dependency in composer.json from ^1.1.1 to ^2.0.0. This moves to a major release which may include breaking changes—run composer update and test the application to verify compatibility.