### PR TITLE
Bump glueful/users to ^2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "glueful/email-notification": "^1.10.0",
     "glueful/framework": "^1.61.1",
     "glueful/media": "^1.1.0",
-    "glueful/users": "^2.0.0"
+    "glueful/users": "^2.1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update glueful/users requirement from ^2.0.0 to ^2.1.0 in composer.json to pick up the latest minor fixes and improvements. After merging, run composer update and run tests to verify compatibility.