### PR TITLE
Bump glueful/users to ^2.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "glueful/email-notification": "^1.10.0",
     "glueful/framework": "^1.61.1",
     "glueful/media": "^1.1.0",
-    "glueful/users": "^2.1.0"
+    "glueful/users": "^2.1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update composer.json to require glueful/users ^2.1.1 (was ^2.1.0). Pulls in the newer patch release for glueful/users; no other changes in this commit.