### PR TITLE
Bump framework and users package versions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "glueful/email-notification": "^1.10.0",
     "glueful/framework": "^1.61.2",
     "glueful/media": "^1.1.0",
-    "glueful/users": "^2.1.1"
+    "glueful/users": "^2.1.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.61.1",
+    "glueful/framework": "^1.61.2",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.1.1"
   },


### PR DESCRIPTION
Update composer.json to require glueful/users ^2.1.2 (was ^2.1.1). This is a patch version bump for the users package.