### PR TITLE
Bump glueful/framework to ^1.63.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.63.0",
+    "glueful/framework": "^1.63.1",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.0"
   },


### PR DESCRIPTION
Update composer.json to require glueful/framework ^1.63.1 (was ^1.63.0). This updates the framework dependency to the new patch release to pick up bug fixes or improvements; no other files were modified.