### PR TITLE
Bump glueful/framework to ^1.63.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.63.1",
+    "glueful/framework": "^1.63.2",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.0"
   },


### PR DESCRIPTION
Update composer.json to require glueful/framework ^1.63.2 (patch bump from ^1.63.1). Run composer update to install the patched dependency and update the lockfile.