### PR TITLE
Bump glueful/framework to ^1.63.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.63.2",
+    "glueful/framework": "^1.63.3",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.0"
   },


### PR DESCRIPTION
Update composer.json to require glueful/framework ^1.63.3 (previously ^1.63.2). This bumps the framework dependency to the latest patch release to pick up fixes/updates in 1.63.3.