### PR TITLE
Add API key prefix config and bump framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ DEFAULT_SECURITY_LEVEL=1
 TOKEN_SALT=
 JWT_ALGORITHM=HS256
 
+# API key brand prefix for generated keys (e.g. gf -> gf_live_… / gf_test_…). Only the first 16
+# chars are stored as the indexed lookup prefix, so keep it short. Default: gf.
+API_KEY_PREFIX=gf
+
 # Email two-factor authentication (opt-in; off by default).
 # When false, the /2fa/* routes are not registered and login is unchanged.
 # To enable: run the 010_AddTwoFactorEnabledToUsers migration, install

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.63.4",
+    "glueful/framework": "^1.64.0",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.0"
   },

--- a/config/auth.php
+++ b/config/auth.php
@@ -9,6 +9,14 @@
  */
 
 return [
+    'api_keys' => [
+        // Brand segment of generated API keys: <prefix>_live_<random> in production,
+        // <prefix>_test_<random> elsewhere. Defaults to 'gf' (Glueful); set API_KEY_PREFIX to
+        // rebrand (e.g. 'lm' → lm_live_… / lm_test_…). Keep it short — only the first 16 chars of a
+        // key are stored as the indexed lookup prefix.
+        'prefix' => env('API_KEY_PREFIX', 'gf'),
+    ],
+
     'two_factor' => [
         // Master switch. When false, TwoFactorService::isEnabled() short-circuits
         // before any DB read and the /2fa/* routes are not registered.


### PR DESCRIPTION
Add support for a configurable API key brand prefix: introduce API_KEY_PREFIX in .env.example (default 'gf') and add an api_keys.prefix entry to config/auth.php (uses env('API_KEY_PREFIX')). This documents that only the first 16 chars are used for indexed lookups. Also bump glueful/framework from ^1.63.4 to ^1.64.0 in composer.json.