### PR TITLE
Bump glueful/framework and users versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.64.0",
+    "glueful/framework": "^1.65.0",
     "glueful/media": "^1.1.0",
-    "glueful/users": "^2.3.0"
+    "glueful/users": "^2.3.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
Update composer.json to require glueful/framework ^1.65.0 and glueful/users ^2.3.1. Keeps project dependencies up-to-date to pick up upstream fixes and improvements.