### PR TITLE
Add in-admin extension installer configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -282,6 +282,17 @@ LOG_RETENTION_AUTH_DAYS=180
 LOG_RETENTION_SECURITY_DAYS=180
 LOG_RETENTION_ERROR_DAYS=180
 
+# Extensions installer (in-admin composer require via the /extensions API).
+# Off in production unless EXTENSIONS_INSTALL_ENABLED is set.
+EXTENSIONS_INSTALL_ENABLED=
+EXTENSIONS_INSTALL_TIMEOUT=600
+# Optional: absolute path to a CLI php used to run composer. Leave blank to
+# auto-detect. Set it when the web SAPI's php is not a usable CLI interpreter
+# (Apache module / php-cgi / nginx+FPM) — e.g. /usr/bin/php on the server.
+EXTENSIONS_INSTALL_PHP_BINARY=
+# Optional: absolute path to the composer binary if it is not on the web PATH.
+COMPOSER_BINARY=
+
 # Event System (core listeners / audit logging)
 EVENTS_ENABLED=true
 EVENTS_AUDIT_LOGGING=true

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
   ],
   "require": {
     "php": "^8.3",
-    "glueful/email-notification": "^1.10.0",
-    "glueful/framework": "^1.65.1",
+    "glueful/email-notification": "^1.12.0",
+    "glueful/framework": "^1.66.2",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.2"
   },

--- a/config/extensions.php
+++ b/config/extensions.php
@@ -34,4 +34,20 @@ return [
         //   php glueful aegis:bootstrap-admin --user=<uuid-or-email>   # syncs catalog, grants users.read, assigns the role
         // 'Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider',
     ],
+
+    /**
+     * In-admin extension installer (composer require via the /extensions API).
+     * Off in production unless EXTENSIONS_INSTALL_ENABLED is explicitly set.
+     * Keep env() reads here — NOT inside `enabled` above (that must stay a
+     * literal list the enable/disable writer can edit).
+     */
+    'install' => [
+        'enabled'    => env('EXTENSIONS_INSTALL_ENABLED', env('APP_ENV') !== 'production'),
+        'timeout'    => (int) env('EXTENSIONS_INSTALL_TIMEOUT', 600),
+        'vendor'     => 'glueful/',
+        // Absolute path to a CLI php used to run composer. Leave null to auto-detect
+        // (PhpExecutableFinder, then PHP_BINARY). Set it when the web SAPI's php is not
+        // a usable CLI interpreter (Apache module / php-cgi / nginx+FPM).
+        'php_binary' => env('EXTENSIONS_INSTALL_PHP_BINARY') ?: null,
+    ],
 ];


### PR DESCRIPTION
Introduces environment variables and configuration for the in-admin extension installer feature, allowing administrators to install extensions via the /extensions API using composer. Includes timeout settings, PHP binary path configuration, and support for custom composer binary paths. Updates framework and email-notification dependencies to versions that support this feature.