### PR TITLE
Update glueful/framework to ^1.71.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.12.0",
-    "glueful/framework": "^1.70.0",
+    "glueful/framework": "^1.71.0",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.2"
   },


### PR DESCRIPTION
Bump glueful/framework dependency from ^1.70.0 to ^1.71.0 to access the latest features and improvements.