### PR TITLE
Bump framework; add protected extensions config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.12.0",
-    "glueful/framework": "^1.71.0",
+    "glueful/framework": "^1.72.1",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.2"
   },

--- a/config/extensions.php
+++ b/config/extensions.php
@@ -16,6 +16,15 @@
  */
 
 return [
+    /**
+     * Providers whose enable/disable is OWNED elsewhere — a domain lifecycle flow (e.g.
+     * glueful/tenancy's enablement state machine) or this product's bundled-required set.
+     * Generic surfaces (extensions:enable|disable, the extensions admin toggle) refuse these
+     * with the recorded reason; the owning flow keeps using ExtensionStateWriter directly.
+     * Shape: 'Fully\\Qualified\\Provider' => ['reason' => '...', 'managed_by' => '...'].
+     */
+    'protected' => [],
+
     'enabled' => [
         // The first-party user store (identity + account lifecycle). Provides the real
         // UserProviderInterface impl; without it core auth fails closed (NullUserProvider).


### PR DESCRIPTION
Update glueful/framework dependency to ^1.72.1 in composer.json. Add a new 'protected' entry to config/extensions.php (empty array) with documentation explaining providers whose enable/disable state is owned elsewhere and the expected shape ('Fully\\Qualified\\Provider' => ['reason' => '...', 'managed_by' => '...']).