### PR TITLE
Add optional session-cookie transport & bump framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,23 @@ DEFAULT_SECURITY_LEVEL=1
 TOKEN_SALT=
 JWT_ALGORITHM=HS256
 
+# Browser session transport (opt-in). Off by default: the session routes are not registered
+# and bearer API authentication is entirely unaffected. Enable it only for browser clients,
+# and add the `session_cookie` middleware to the routes that should accept cookies.
+SESSION_COOKIE_ENABLED=false
+# Host-configurable names so several Glueful apps under one parent domain do not collide.
+SESSION_COOKIE_ACCESS_NAME=gf_session
+SESSION_COOKIE_REFRESH_NAME=gf_refresh
+# Refresh cookie lifetime in seconds (30 days). The access cookie follows the session's own TTL.
+SESSION_COOKIE_REFRESH_TTL=2592000
+SESSION_COOKIE_PATH=/
+# The refresh credential is sent ONLY to the session routes, never on ordinary requests.
+SESSION_COOKIE_REFRESH_PATH=/auth/session
+# Empty means a host-only cookie, which is the safe default.
+SESSION_COOKIE_DOMAIN=
+SESSION_COOKIE_SECURE=true
+SESSION_COOKIE_SAMESITE=lax
+
 # API key brand prefix for generated keys (e.g. gf -> gf_live_… / gf_test_…). Only the first 16
 # chars are stored as the indexed lookup prefix, so keep it short. Default: gf.
 API_KEY_PREFIX=gf

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.3",
     "glueful/email-notification": "^1.12.0",
-    "glueful/framework": "^1.72.1",
+    "glueful/framework": "^1.74.0",
     "glueful/media": "^1.1.0",
     "glueful/users": "^2.3.2"
   },

--- a/config/auth.php
+++ b/config/auth.php
@@ -38,4 +38,32 @@ return [
         // re-verifying (seconds). Session-scoped marker, not user-scoped.
         'disable_freshness' => (int) env('TWO_FACTOR_DISABLE_FRESHNESS', 300),
     ],
+
+    /**
+     * Opt-in browser-session transport. Off by default: a fresh install behaves exactly like
+     * a pre-cookie framework until SESSION_COOKIE_ENABLED=true, and while disabled the session
+     * routes are not registered at all. Bearer authentication is unaffected either way.
+     */
+    'session_cookie' => [
+        'enabled' => env('SESSION_COOKIE_ENABLED', false),
+
+        // Host-configurable so several Glueful apps under one parent domain do not collide.
+        'access_name' => env('SESSION_COOKIE_ACCESS_NAME', 'gf_session'),
+        'refresh_name' => env('SESSION_COOKIE_REFRESH_NAME', 'gf_refresh'),
+
+        // How long the refresh cookie itself survives (seconds). The access cookie follows
+        // the issued session's own expires_in.
+        'refresh_ttl' => (int) env('SESSION_COOKIE_REFRESH_TTL', 2592000),
+
+        'path' => env('SESSION_COOKIE_PATH', '/'),
+
+        // The refresh credential is sent ONLY to the session routes, never on ordinary requests.
+        'refresh_path' => env('SESSION_COOKIE_REFRESH_PATH', '/auth/session'),
+
+        // Null means a host-only cookie, which is the safe default.
+        'domain' => env('SESSION_COOKIE_DOMAIN', null),
+
+        'secure' => env('SESSION_COOKIE_SECURE', true),
+        'same_site' => env('SESSION_COOKIE_SAMESITE', 'lax'),
+    ],
 ];


### PR DESCRIPTION
Introduce an opt-in browser session cookie transport. Adds SESSION_COOKIE_* env vars to .env.example and a 'session_cookie' config block in config/auth.php (disabled by default). Provides configurable access/refresh names, refresh TTL/path/domain, secure and same_site options. Session routes are only registered when enabled; bearer API auth is unaffected. Also bump glueful/framework to ^1.74.0 in composer.json.